### PR TITLE
Disable fail-fast for tests.

### DIFF
--- a/.github/workflows/ci-4.x.yml
+++ b/.github/workflows/ci-4.x.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   CI:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/.github/workflows/ci-5.x.yml
+++ b/.github/workflows/ci-5.x.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   CI:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest


### PR DESCRIPTION
By default github cancels matrix tests if one fails, this behavior makes debugging test failures more difficult to isolate as it is not obvious if a failure is common to other tests if they get cancelled automatically.